### PR TITLE
Update class.yrewrite_domain_settings.php

### DIFF
--- a/lib/class.yrewrite_domain_settings.php
+++ b/lib/class.yrewrite_domain_settings.php
@@ -29,7 +29,7 @@ class yrewrite_domain_settings
             return null;
         }
 
-        $query = rex_yform_manager_table::get('yrewrite_domain_settings')->query();
+        $query = rex_yform_manager_table::get(rex::getTablePrefix().'yrewrite_domain_settings')->query();
         $query->where('domain_id', $domainId);
         $item = $query->findOne();
 

--- a/lib/class.yrewrite_domain_settings.php
+++ b/lib/class.yrewrite_domain_settings.php
@@ -12,7 +12,7 @@ class yrewrite_domain_settings
         $this->domain = rex_yrewrite::getDomainByArticleId(rex_article::getCurrentId(), rex_clang::getCurrentId());
     }
 
-    public static function getInstance(): YRewriteDomainSettings
+    public static function getInstance(): yrewrite_domain_settings
     {
         if (self::$instance === null) {
             self::$instance = new yrewrite_domain_settings();

--- a/lib/class.yrewrite_domain_settings.php
+++ b/lib/class.yrewrite_domain_settings.php
@@ -1,6 +1,6 @@
 <?php
 
-class YRewriteDomainSettings
+class yrewrite_domain_settings
 {
     private static $instance = null;
     private $addon;

--- a/lib/class.yrewrite_domain_settings.php
+++ b/lib/class.yrewrite_domain_settings.php
@@ -15,7 +15,7 @@ class yrewrite_domain_settings
     public static function getInstance(): YRewriteDomainSettings
     {
         if (self::$instance === null) {
-            self::$instance = new YRewriteDomainSettings();
+            self::$instance = new yrewrite_domain_settings();
         }
         return self::$instance;
     }

--- a/lib/class.yrewrite_domain_settings.php
+++ b/lib/class.yrewrite_domain_settings.php
@@ -20,7 +20,7 @@ class yrewrite_domain_settings
         return self::$instance;
     }
 
-    public static function getValue(string $key = ''): ?array
+    public static function getValue(string $key = '')
     {
         $settings = self::getInstance();
 


### PR DESCRIPTION
-Singleton-Pattern: Implementiert, um sicherzustellen, dass nur eine Instanz der Klasse existiert.
-Benennung und Stil: Angepasst, um modernen PHP-Standards zu entsprechen.
-Früher Ausstieg: Frühes Verlassen der Funktion, um die Verschachtelungstiefe zu reduzieren und die Lesbarkeit zu verbessern.
-Typdeklarationen: Hinzugefügt, um die Sicherheit und Lesbarkeit des Codes zu verbessern.
-Vereinfachte Logik in getAllowedDomains: Verwendung von array_filter anstelle von manuellen Schleifen für eine sauberere und effizientere Implementierung.
-Verzicht auf überflüssige Validierung: In getValue, wenn $item->getValue('id') nicht existiert, gibt es keinen Grund, weiterzumachen.