### PR TITLE
Fix Prüfung der Domain-Rechte

### DIFF
--- a/lib/class.yrewrite_domain_settings.php
+++ b/lib/class.yrewrite_domain_settings.php
@@ -51,7 +51,7 @@ class yrewrite_domain_settings
 
         $allowedDomains = $user->getComplexPerm('yrewrite_domains')->getDomains();
         return array_filter($allDomains, function($domain) use ($allowedDomains) {
-            return in_array($domain['id'], $allowedDomains, true);
+            return in_array($domain['id'], $allowedDomains, false);
         });
     }
 }


### PR DESCRIPTION
"strict" ist schlecht an der Stelle, da "$domain['id']" ein "int" ist, aber die id in "allowedDomains" ein string.