### PR TITLE
YForm 5 ermöglichen

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: yrewrite_domain_settings
-version: '2.2.0'
+version: '2.3.0'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/yrewrite_domain_settings
     
@@ -7,7 +7,7 @@ requires:
     redaxo: '^5.5'
     packages:
         yrewrite: '^2.5'
-        yform: '>3.0, <5'
+        yform: '>3.0, <6'
     php:
         version: '>=5.6'
 


### PR DESCRIPTION
Das Addon selbst scheint mir bzgl YForm 5 unkritisch zu sein. Allerdings muss die Voraussetzung lt. package.yml auf YForm 5 erweitert werden.